### PR TITLE
Fix failing unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   - pip install --upgrade pip==9.0.1
   - pip install -r requirements.txt
-  - pip install tox==3.0.0 tox-travis==0.10
+  - pip install tox==3.0.0 tox-travis==0.10 more-itertools==5.0.0
 before_script:
   - make docker-images
   - make presto-server-rpm.rpm

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -53,7 +53,7 @@ class TestCollect(BaseUnitCase):
                                                PRESTOADMIN_LOG_NAME),
                                      downloaded_logs_loc)
 
-        tarfile_open_mock.assert_called_with(OUTPUT_FILENAME_FOR_LOGS, 'w:gz')
+        tarfile_open_mock.assert_called_with(TMP_PRESTO_DEBUG + OUTPUT_FILENAME_FOR_LOGS, 'w:gz')
         tar = tarfile_open_mock.return_value
         tar.add.assert_called_with(downloaded_logs_loc,
                                    arcname=path.basename(downloaded_logs_loc))

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -295,13 +295,13 @@ class TestInstall(BaseUnitCase):
                                                location='none')
 
     def test_specifier_as_version_download(self):
-        self.check_rpm_specifier_with_location(rpm_specifier='0.144.6', location='download')
+        self.check_rpm_specifier_with_location(rpm_specifier='322', location='download')
 
     def test_specifier_as_version_found_locally(self):
-        self.check_rpm_specifier_with_location(rpm_specifier='0.144.6', location='local')
+        self.check_rpm_specifier_with_location(rpm_specifier='322', location='local')
 
     def test_specifier_as_version_not_located(self):
-        self.check_rpm_specifier_with_location(rpm_specifier='0.144.6', location='none')
+        self.check_rpm_specifier_with_location(rpm_specifier='322', location='none')
 
     def test_specifier_as_local_path_without_file_scheme_found_locally(self):
         self.check_rpm_specifier_with_location(rpm_specifier='/path/to/rpm', location='local')


### PR DESCRIPTION
- Pin the more-itertools package because it is causing syntax errors
  with higher versions.
- Adjust version to test in RPM download tests.
- Update path for log collection archive.