### PR TITLE
Update jvm.config defaults

### DIFF
--- a/prestoadmin/coordinator.py
+++ b/prestoadmin/coordinator.py
@@ -45,11 +45,14 @@ class Coordinator(Node):
                                          '-XX:+UseG1GC',
                                          '-XX:G1HeapRegionSize=32M',
                                          '-XX:+ExplicitGCInvokesConcurrent',
-                                         '-XX:+HeapDumpOnOutOfMemoryError',
-                                         '-XX:+UseGCOverheadLimit',
                                          '-XX:+ExitOnOutOfMemoryError',
+                                         '-XX:+UseGCOverheadLimit',
+                                         '-XX:+HeapDumpOnOutOfMemoryError',
                                          '-XX:ReservedCodeCacheSize=512M',
-                                         '-DHADOOP_USER_NAME=hive'],
+                                         '-Djdk.attach.allowAttachSelf=true',
+                                         '-Djdk.nio.maxCachedBufferSize=2000000',
+                                         '-DHADOOP_USER_NAME=hive',  # not Presto default
+                                         ],
                           'config.properties': {
                               'coordinator': 'true',
                               'discovery-server.enabled': 'true',

--- a/prestoadmin/workers.py
+++ b/prestoadmin/workers.py
@@ -48,11 +48,14 @@ class Worker(Node):
                                          '-XX:+UseG1GC',
                                          '-XX:G1HeapRegionSize=32M',
                                          '-XX:+ExplicitGCInvokesConcurrent',
-                                         '-XX:+HeapDumpOnOutOfMemoryError',
-                                         '-XX:+UseGCOverheadLimit',
                                          '-XX:+ExitOnOutOfMemoryError',
+                                         '-XX:+UseGCOverheadLimit',
+                                         '-XX:+HeapDumpOnOutOfMemoryError',
                                          '-XX:ReservedCodeCacheSize=512M',
-                                         '-DHADOOP_USER_NAME=hive'],
+                                         '-Djdk.attach.allowAttachSelf=true',
+                                         '-Djdk.nio.maxCachedBufferSize=2000000',
+                                         '-DHADOOP_USER_NAME=hive',  # not Presto default
+                                         ],
                           'config.properties': {'coordinator': 'false',
                                                 'http-server.http.port':
                                                     '8080',


### PR DESCRIPTION
Update `jvm.config` defaults we provide to Presto's defaults
https://github.com/prestosql/presto/blob/329/presto-server-rpm/src/main/resources/dist/config/jvm.config