### PR TITLE
Add support for updated Trino version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ presto-admin-test/target
 
 # presto yarn package for product tests
 presto-yarn-package.zip
+
+# python virtual env
+venv/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # trino-admin [![Build Status](https://travis-ci.org/github/trinodb/trino-admin.svg?branch=master)](https://travis-ci.org/github/trinodb/trino-admin)
 
-## Trino-admin (formerly known as presto-admin) is deprecated and will not work with new versions of Trino (>350)
-
 Trino-admin installs, configures, and manages Trino installations.
 
 Comprehensive documentation(deprecated) can be found at https://trinodb.github.io/trino-admin/docs/current/index.html 
@@ -15,7 +13,7 @@ Comprehensive documentation(deprecated) can be found at https://trinodb.github.i
       Ubuntu 14.04. 
     * If you have Docker already installed, you need to make sure that your user has
       been added to the docker group. This will enable you to run commands without `sudo`,
-      which is a requirement for some of the unit tests. To enable sudoless docker access
+      which is a requirement for some unit tests. To enable sudoless docker access
       run the following:
 
             $ sudo groupadd docker
@@ -50,7 +48,7 @@ In order to get started with `trino-admin`,
      Now you can make your changes locally.
 
 5. When you're done making changes, check that your changes pass `make clean lint test`, which runs flake8 and the unit tests (which test both Python 2.6 and 2.7).
-To run the product tests tests (`make test-all`), you need docker installed. You may also need to run `pip install wheel` in your virtualenv. To install and start docker use ::
+To run the product tests (`make test-all`), you need docker installed. You may also need to run `pip install wheel` in your virtualenv. To install and start docker use ::
 
         $ wget -qO- https://get.docker.com/ | sh
 

--- a/prestoadmin/coordinator.py
+++ b/prestoadmin/coordinator.py
@@ -22,6 +22,7 @@ import logging
 
 from fabric.api import env
 
+from prestoadmin.util import constants
 from prestoadmin.node import Node
 from prestoadmin.presto_conf import validate_presto_conf
 from prestoadmin.util.exception import ConfigurationError
@@ -32,13 +33,14 @@ _LOGGER = logging.getLogger(__name__)
 
 class Coordinator(Node):
     DEFAULT_PROPERTIES = {'node.properties':
-                          {'node.environment': 'presto',
-                           'node.data-dir': '/var/lib/presto/data',
+                          {'node.environment': constants.BRAND,
+                           'node.data-dir': '/var/lib/{}/data'.format(constants.BRAND),
                            'node.launcher-log-file':
-                               '/var/log/presto/launcher.log',
+                               '/var/log/{}/launcher.log'.format(constants.BRAND),
                            'node.server-log-file':
-                               '/var/log/presto/server.log',
-                           'catalog.config-dir': '/etc/presto/catalog'},
+                               '/var/log/{}/server.log'.format(constants.BRAND),
+                           'catalog.config-dir': '/etc/{}/catalog'.format(constants.BRAND),
+                           'plugin.dir': '/usr/lib/{}/lib/plugin'.format(constants.BRAND)},
                           'jvm.config': ['-server',
                                          '-Xmx16G',
                                          '-XX:-UseBiasedLocking',

--- a/prestoadmin/package.py
+++ b/prestoadmin/package.py
@@ -92,11 +92,14 @@ def deploy(local_path=None):
 def _rpm_install(package_path):
     nodeps = _nodeps_rpm_option()
 
-    if 'java_home' not in env or env.java_home is None:
-        return sudo('rpm -i %s%s' % (nodeps, package_path))
-    else:
-        with shell_env(JAVA_HOME='%s' % env.java_home):
+    if 'java11_home' in env and env.java11_home:
+        with shell_env(JAVA11_HOME='%s' % env.java11_home):
             return sudo('rpm -i %s%s' % (nodeps, package_path))
+    elif 'java8_home' in env and env.java8_home:
+        with shell_env(JAVA8_HOME='%s' % env.java8_home):
+            return sudo('rpm -i %s%s' % (nodeps, package_path))
+    else:
+        return sudo('rpm -i %s%s' % (nodeps, package_path))
 
 
 def _nodeps_rpm_option():

--- a/prestoadmin/standalone/config.py
+++ b/prestoadmin/standalone/config.py
@@ -15,6 +15,7 @@
 """
 Module for setting and validating the presto-admin config
 """
+import os
 import re
 
 from fabric.api import env
@@ -22,6 +23,7 @@ from overrides import overrides
 
 import prestoadmin.util.fabricapi as util
 from prestoadmin import config
+from prestoadmin.util import constants
 from prestoadmin.prestoclient import CERTIFICATE_ALIAS
 from prestoadmin.util.base_config import BaseConfig, SingleConfigItem
 from prestoadmin.util.exception import ConfigurationError
@@ -30,8 +32,8 @@ from prestoadmin.util.validators import validate_username, validate_port, \
     validate_host
 
 # Created by the presto-server RPM package.
-PRESTO_STANDALONE_USER = 'presto'
-PRESTO_STANDALONE_GROUP = 'presto'
+PRESTO_STANDALONE_USER = os.environ.get('PRESTO_USER', constants.BRAND)
+PRESTO_STANDALONE_GROUP = os.environ.get('PRESTO_GROUP', constants.BRAND)
 PRESTO_STANDALONE_USER_GROUP = "%s:%s" % (PRESTO_STANDALONE_USER,
                                           PRESTO_STANDALONE_GROUP)
 

--- a/prestoadmin/util/constants.py
+++ b/prestoadmin/util/constants.py
@@ -18,6 +18,7 @@ the presto admin project.
 """
 
 import os
+import sys
 
 import prestoadmin
 
@@ -26,6 +27,17 @@ LOGGING_CONFIG_FILE_NAME = 'presto-admin-logging.ini'
 LOGGING_CONFIG_FILE_DIRECTORIES = [
     os.path.join(prestoadmin.main_dir, 'prestoadmin')
 ]
+
+# Use the BRAND variable to define whether facebook's presto or trinodb's trino is being used at the time
+# with the default value being the former.
+# You can override the default by defining the environment variable PRESTO_TYPE.
+# For example, PRESTO_TYPE=trino means use the latter
+BRAND = os.environ.get('PRESTO_TYPE', 'presto').lower()
+if BRAND == 'trinodb':
+    BRAND = 'trino'
+if BRAND not in ['trino', 'presto']:
+    print >> sys.stderr, "PRESTO_TYPE only support trino and presto"
+    BRAND = 'presto'
 
 # local configuration
 LOG_DIR_ENV_VARIABLE = 'PRESTO_ADMIN_LOG_DIR'
@@ -38,12 +50,12 @@ WORKERS_DIR_NAME = 'workers'
 CATALOG_DIR_NAME = 'catalog'
 
 # remote configuration
-REMOTE_CONF_DIR = '/etc/presto'
+REMOTE_CONF_DIR = '/etc/' + BRAND
 REMOTE_CATALOG_DIR = os.path.join(REMOTE_CONF_DIR, 'catalog')
 REMOTE_PACKAGES_PATH = '/opt/prestoadmin/packages'
-DEFAULT_PRESTO_SERVER_LOG_FILE = '/var/log/presto/server.log'
-DEFAULT_PRESTO_LAUNCHER_LOG_FILE = '/var/log/presto/launcher.log'
-REMOTE_PLUGIN_DIR = '/usr/lib/presto/plugin'
+DEFAULT_PRESTO_SERVER_LOG_FILE = '/var/log/' + BRAND + '/server.log'
+DEFAULT_PRESTO_LAUNCHER_LOG_FILE = '/var/log/' + BRAND + '/launcher.log'
+REMOTE_PLUGIN_DIR = '/usr/lib/' + BRAND + '/plugin'
 REMOTE_COPY_DIR = '/tmp'
 
 # Presto configuration files

--- a/prestoadmin/workers.py
+++ b/prestoadmin/workers.py
@@ -27,6 +27,7 @@ from fabric.api import env
 import prestoadmin.util.fabricapi as util
 from prestoadmin.node import Node
 from prestoadmin.presto_conf import validate_presto_conf
+from prestoadmin.util import constants
 from prestoadmin.util.exception import ConfigurationError
 from prestoadmin.util.local_config_util import get_workers_directory
 
@@ -35,13 +36,14 @@ _LOGGER = logging.getLogger(__name__)
 
 class Worker(Node):
     DEFAULT_PROPERTIES = {'node.properties':
-                          {'node.environment': 'presto',
-                           'node.data-dir': '/var/lib/presto/data',
-                           'node.launcher-log-file':
-                               '/var/log/presto/launcher.log',
-                           'node.server-log-file':
-                               '/var/log/presto/server.log',
-                           'catalog.config-dir': '/etc/presto/catalog'},
+                              {'node.environment': constants.BRAND,
+                               'node.data-dir': '/var/lib/{}/data'.format(constants.BRAND),
+                               'node.launcher-log-file':
+                                   '/var/log/{}/launcher.log'.format(constants.BRAND),
+                               'node.server-log-file':
+                                   '/var/log/{}/server.log'.format(constants.BRAND),
+                               'catalog.config-dir': '/etc/{}/catalog'.format(constants.BRAND),
+                               'plugin.dir': '/usr/lib/{}/lib/plugin'.format(constants.BRAND)},
                           'jvm.config': ['-server',
                                          '-Xmx16G',
                                          '-XX:-UseBiasedLocking',


### PR DESCRIPTION
Support trino version 350 or later
----

If you are using trino 350 or later, you can export an environment variable `PRESTO_TYPE=trino` before using the tool, the following .

Here is a running example

```
# PRESTO_TYPE=trino presto-admin server status
Server Status:
        node1(IP: xxx.xxx.xxx.xxx, Roles: coordinator): Running
        Node URI(http): http://xxx.xxx.xxx.xxx:58080
        Trino Version: 359
        Node status:    active
        Catalogs:     hbase, hive, system
Server Status:
        sjzl-web.ds.cfzq.com(IP: xxx.xxx.xxx.xxx, Roles: worker): Running
        Node URI(http): http://xxx.xxx.xxx.xxx:58080
        Trino Version: 359
        Node status:    active
        Catalogs:     hbase, hive, system
Server Status:
        sjzl-db.ds.cfzq.com(IP: xxx.xxx.xxx.xxx, Roles: worker): Running
        Node URI(http): http://xxx.xxx.xxx.xxx:58080
        Trino Version: 359
        Node status:    active
        Catalogs:     hbase, hive, system
Server Status:
        hdp41.ds.cfzq.com(IP: xxx.xxx.xxx.xxx, Roles: worker): Running
        Node URI(http): http://xxx.xxx.xxx.xxx:58080
        Trino Version: 359
        Node status:    active
        Catalogs:     hbase, hive, system
Server Status:
        hdp42.ds.cfzq.com(IP: xxx.xxx.xxx.xxx, Roles: worker): Running
        Node URI(http): http://xxx.xxx.xxx.xxx:58080
        Trino Version: 359
        Node status:    active
        Catalogs:     hbase, hive, system
Server Status:
        hdp43.ds.cfzq.com(IP: xxx.xxx.xxx.xxx, Roles: worker): Running
        Node URI(http): http://xxx.xxx.xxx.xxx:58080
        Trino Version: 359
        Node status:    active
        Catalogs:     hbase, hive, system
```